### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 .DS_Store
 
 coverage.html
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
+A transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
+
 ## Install
 
 ```sh
@@ -69,8 +71,6 @@ The client will balance requests over both servers using round-robin.
 See [test/](test/) for more usage examples.
 
 ## Motivation
-
-A transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
 
 This module is a plugin for the Seneca framework. It provides a transport client that load balances outbound messages on a per-pattern basis.
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,10 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js][] plugin
 
-> A [Seneca.js][] transport plugin that provides various client-side
-load balancing strategies, and enables dynamic reconfiguration of
-client message routing.
+# @seneca/balance-client
 
-# seneca-balance-client
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter][gitter-badge]][gitter-url]
-
-## Description
-
-This module is a plugin for the Seneca framework. It provides a
-transport client that load balances outbound messages on a per-pattern basis.
-
-If you're using this module, and need help, you can:
-
-- Post a [github issue][],
-- Tweet to [@senecajs][],
-- Ask on the [Gitter][gitter-url].
-
-If you are new to Seneca in general, please take a look at
-[Senecajs.org][]. We have everything from tutorials to sample apps to
-help get you up and running quickly.
-
-### Seneca compatibility
-Supports Seneca versions **3.x** and above.
-
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
 
@@ -89,94 +65,52 @@ will apply to all non-local actions. Add a _pin_ to restrict the
 action patterns to which this applies - make sure to use the same
 _pin_ on both client and server to avoid ambiguity.
 
-## Usage
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+This module is a plugin for the Seneca framework. It provides a transport client that load balances outbound messages on a per-pattern basis.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+- Ask on the [Gitter][gitter-url]
+
+## API
 
 The plugin provides two balancing models:
 
-* `consume`: messages are sent to individual targets, using a round-robin approach
-* `observe`: messages are duplicated and sent to all targets
+- `consume`: messages are sent to individual targets using round-robin
+- `observe`: messages are duplicated and sent to all targets
 
-You specify the model using the plugin option `model`:
-
-```js
-var Seneca = require('seneca')
-
-var s0 = Seneca({tag: 's0'})
-  .listen(44440)
-  .add('a:1', function (msg, done) {
-    console.log('s0;x='+msg.x);
-    done()
-  })
-
-var s1 = Seneca({tag: 's1'})
-  .listen(44441)
-  .add('a:1', function (msg, done) {
-    console.log('s1;x='+msg.x);
-    done()
-  })
-
-var c0 = Seneca({tag: 'c0'})
-  .use('..')
-  .client({ type: 'balance', pin: 'a:1', model: 'observe' })
-  .client({ port: 44440, pin: 'a:1' })
-  .client({ port: 44441, pin: 'a:1' })
-
-
-s0.ready( s1.ready.bind(s1, c0.ready.bind(c0, function () {
-  c0.act('a:1,x:y')
-
-  // wait a little bit to avoid shutting down in mid flow
-  setTimeout(
-    s0.close.bind( s0, s1.close.bind(s1, c0.close.bind(c0))), 111 )
-})))
-```
-
-You can also provide your own balancing model by providing a function
-with signature `(seneca, msg, targetstate, done)` as the value of the
-`model` setting:
-
-```js
-...
-    .client({
-      type: 'balance',
-      pin: 'a:1',
-      model: function (seneca, msg, targetstate, done) {
-        if (0 === targetstate.targets.length) {
-          return done( new Error('No targets') )
-        }
-
-        // select a random target
-        var index = Math.floor(Math.random() * targetstate.targets.length)
-        targetstate.targets[index].action.call( seneca, msg, done)
-      }
-    })
-...
-```
-
-The `targetstate` object provides you with the list of currently
-available targets.  Review the internal implementations of the
-`observeModel` and the `consumeModel` in
-[balance-client.js](https://github.com/senecajs/seneca-balance-client/blob/master/balance-client.js)
-for a starting point to write your own model.
-
+Specify the model using the `model` plugin option.
 
 ## Contributing
 
-The [Senecajs org][] encourages open participation. If you feel you
-can help in any way, be it with documentation, examples, extra
-testing, or new features please get in touch.
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
-## Test
-To run tests, simply use npm:
+### Running tests
 
 ```sh
 npm run test
 ```
 
-## License
-Copyright (c) 2010-2016, Richard Rodger and other contributors.
-Licensed under [MIT][].
+## Background
 
+See [seneca-transport](http://github.com/rjrodger/seneca-transport) for more information about message transports.
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Coverage Status][coveralls-badge]][coveralls-url]
+[![Dependency Status][david-badge]][david-url]
+[![Gitter][gitter-badge]][gitter-url]
+[Senecajs.org][]. We have everything from tutorials to sample apps to
+[balance-client.js](https://github.com/senecajs/seneca-balance-client/blob/master/balance-client.js)
 [MIT]: ./LICENSE
 [npm-badge]: https://img.shields.io/npm/v/seneca-balance-client.svg
 [npm-url]: https://npmjs.com/package/seneca-balance-client

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
-A transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
-
 ## Install
 
 ```sh
@@ -71,6 +69,8 @@ The client will balance requests over both servers using round-robin.
 See [test/](test/) for more usage examples.
 
 ## Motivation
+
+A transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
 
 This module is a plugin for the Seneca framework. It provides a transport client that load balances outbound messages on a per-pattern basis.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 load balancing strategies, and enables dynamic reconfiguration of
 client message routing.
 
-# seneca-balance-client
+# @seneca/balance-client
 [![npm version][npm-badge]][npm-url]
 [![Build Status][travis-badge]][travis-url]
 [![Coverage Status][coveralls-badge]][coveralls-url]

--- a/README.md
+++ b/README.md
@@ -117,7 +117,35 @@ var c0 = Seneca({tag: 'c0'})
   .client({ port: 44441, pin: 'a:1' })
 ```
 
-You can also provide your own balancing model by providing a function with signature `(seneca, msg, targetstate, done)` as the value of the `model` setting.
+
+
+You can also provide your own balancing model by providing a function
+with signature `(seneca, msg, targetstate, done)` as the value of the
+`model` setting:
+
+```js
+...
+    .client({
+      type: 'balance',
+      pin: 'a:1',
+      model: function (seneca, msg, targetstate, done) {
+        if (0 === targetstate.targets.length) {
+          return done( new Error('No targets') )
+        }
+
+        // select a random target
+        var index = Math.floor(Math.random() * targetstate.targets.length)
+        targetstate.targets[index].action.call( seneca, msg, done)
+      }
+    })
+...
+```
+
+The `targetstate` object provides you with the list of currently
+available targets. Review the internal implementations of the
+`observeModel` and the `consumeModel` in
+[balance-client.js](https://github.com/senecajs/seneca-balance-client/blob/master/balance-client.js)
+for a starting point to write your own model.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ load balancing strategies, and enables dynamic reconfiguration of
 client message routing.
 
 # @seneca/balance-client
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter][gitter-badge]][gitter-url]
+[![build](https://github.com/senecajs/seneca-balance-client/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-balance-client/actions/workflows/build.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-balance-client/badge.svg)](https://snyk.io/test/github/senecajs/seneca-balance-client)
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -85,7 +82,6 @@ require('seneca')()
 
   })
 
-
 // $ node client.js --seneca.log=type:act
 ```
 
@@ -134,26 +130,11 @@ npm run test
 
 See [seneca-transport](http://github.com/rjrodger/seneca-transport) for more information about message transports.
 
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter][gitter-badge]][gitter-url]
 [Senecajs.org][]. We have everything from tutorials to sample apps to
 [balance-client.js](https://github.com/senecajs/seneca-balance-client/blob/master/balance-client.js)
 [MIT]: ./LICENSE
-[npm-badge]: https://img.shields.io/npm/v/seneca-balance-client.svg
-[npm-url]: https://npmjs.com/package/seneca-balance-client
-[coveralls-badge]:https://coveralls.io/repos/senecajs/seneca-balance-client/badge.svg?branch=master&service=github
-[coveralls-url]: https://coveralls.io/github/senecajs/seneca-balance-client?branch=master
-[david-badge]: https://david-dm.org/senecajs/seneca-balance-client.svg
-[david-url]: https://david-dm.org/senecajs/seneca-balance-client
 [Senecajs org]: https://github.com/senecajs/
 [Seneca.js]: https://www.npmjs.com/package/seneca
 [@senecajs]: http://twitter.com/senecajs
 [senecajs.org]: http://senecajs.org/
-[travis-badge]: https://travis-ci.org/senecajs/seneca-balance-client.svg
-[travis-url]: https://travis-ci.org/senecajs/seneca-balance-client
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
-[gitter-url]: https://gitter.im/senecajs/seneca
 [github issue]: https://github.com/senecajs/seneca-balance-client/issues

--- a/README.md
+++ b/README.md
@@ -1,34 +1,11 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js][] plugin
-
-> A [Seneca.js][] transport plugin that provides various client-side
-load balancing strategies, and enables dynamic reconfiguration of
-client message routing.
+> A [Seneca.js](http://senecajs.org) transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
 
 # @seneca/balance-client
+
 [![build](https://github.com/senecajs/seneca-balance-client/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-balance-client/actions/workflows/build.yml)
+[![Coverage Status](https://coveralls.io/repos/senecajs/seneca-balance-client/badge.svg?branch=master&service=github)](https://coveralls.io/github/senecajs/seneca-balance-client?branch=master)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-balance-client/badge.svg)](https://snyk.io/test/github/senecajs/seneca-balance-client)
-
-| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
-|---|---|
-
-### Description
-
-This module is a plugin for the Seneca framework. It provides a
-transport client that load balances outbound messages on a per-pattern basis.
-
-If you're using this module, and need help, you can:
-
-- Post a [github issue][],
-- Tweet to [@senecajs][],
-- Ask on the [Gitter][gitter-url].
-
-If you are new to Seneca in general, please take a look at
-[Senecajs.org][]. We have everything from tutorials to sample apps to
-help get you up and running quickly.
-
-### Seneca compatibility
-Supports Seneca versions **3.x** and above.
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -36,7 +13,7 @@ Supports Seneca versions **3.x** and above.
 ## Install
 
 ```sh
-npm install seneca-balance-client
+npm install @seneca/balance-client
 ```
 
 And in your code:
@@ -85,40 +62,66 @@ require('seneca')()
 // $ node client.js --seneca.log=type:act
 ```
 
-The client will balance requests over both servers using
-round-robin. As there is no _pin_ in the `.client` configuration, this
-will apply to all non-local actions. Add a _pin_ to restrict the
-action patterns to which this applies - make sure to use the same
-_pin_ on both client and server to avoid ambiguity.
+The client will balance requests over both servers using round-robin.
 
 ## More Examples
 
-See [test/](test/) for usage examples.
+See [test/](test/) for more usage examples.
 
 ## Motivation
 
 This module is a plugin for the Seneca framework. It provides a transport client that load balances outbound messages on a per-pattern basis.
 
+Supports Seneca versions **3.x** and above.
+
 ## Support
 
 If you're using this module and need help, you can:
 
-- Post a [github issue][]
-- Tweet to [@senecajs][]
-- Ask on the [Gitter][gitter-url]
+- Post a [github issue](https://github.com/senecajs/seneca-balance-client/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
 
 ## API
 
+### Usage
+
 The plugin provides two balancing models:
 
-- `consume`: messages are sent to individual targets using round-robin
-- `observe`: messages are duplicated and sent to all targets
+* `consume`: messages are sent to individual targets, using a round-robin approach
+* `observe`: messages are duplicated and sent to all targets
 
-Specify the model using the `model` plugin option.
+You specify the model using the plugin option `model`:
+
+```js
+var Seneca = require('seneca')
+
+var s0 = Seneca({tag: 's0'})
+  .listen(44440)
+  .add('a:1', function (msg, done) {
+    console.log('s0;x='+msg.x);
+    done()
+  })
+
+var s1 = Seneca({tag: 's1'})
+  .listen(44441)
+  .add('a:1', function (msg, done) {
+    console.log('s1;x='+msg.x);
+    done()
+  })
+
+var c0 = Seneca({tag: 'c0'})
+  .use('..')
+  .client({ type: 'balance', pin: 'a:1', model: 'observe' })
+  .client({ port: 44440, pin: 'a:1' })
+  .client({ port: 44441, pin: 'a:1' })
+```
+
+You can also provide your own balancing model by providing a function with signature `(seneca, msg, targetstate, done)` as the value of the `model` setting.
 
 ## Contributing
 
-The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
 ### Running tests
 
@@ -128,13 +131,7 @@ npm run test
 
 ## Background
 
-See [seneca-transport](http://github.com/rjrodger/seneca-transport) for more information about message transports.
+Copyright (c) 2010-2016, Richard Rodger and other contributors.
+Licensed under [MIT](./LICENSE).
 
-[Senecajs.org][]. We have everything from tutorials to sample apps to
-[balance-client.js](https://github.com/senecajs/seneca-balance-client/blob/master/balance-client.js)
-[MIT]: ./LICENSE
-[Senecajs org]: https://github.com/senecajs/
-[Seneca.js]: https://www.npmjs.com/package/seneca
-[@senecajs]: http://twitter.com/senecajs
-[senecajs.org]: http://senecajs.org/
-[github issue]: https://github.com/senecajs/seneca-balance-client/issues
+Part of the [Senecajs org](https://github.com/senecajs/).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 # @seneca/balance-client
 
+[![npm version](https://img.shields.io/npm/v/seneca-balance-client.svg)](https://npmjs.com/package/seneca-balance-client)
 [![build](https://github.com/senecajs/seneca-balance-client/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-balance-client/actions/workflows/build.yml)
 [![Coverage Status](https://coveralls.io/repos/senecajs/seneca-balance-client/badge.svg?branch=master&service=github)](https://coveralls.io/github/senecajs/seneca-balance-client?branch=master)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-balance-client/badge.svg)](https://snyk.io/test/github/senecajs/seneca-balance-client)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client message routing.
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
-## Description
+### Description
 
 This module is a plugin for the Seneca framework. It provides a
 transport client that load balances outbound messages on a per-pattern basis.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js](http://senecajs.org) transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
+> A [Seneca.js](http://senecajs.org) plugin
 
 # @seneca/balance-client
 
@@ -9,6 +9,8 @@
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
+
+A transport plugin that provides various client-side load balancing strategies, and enables dynamic reconfiguration of client message routing.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-balance-client",
+  "name": "@seneca/balance-client",
   "version": "1.2.0",
   "description": "Seneca client-side load balancing transport.",
   "main": "balance-client.js",


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`